### PR TITLE
Updated Goodreads dataset link

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The datasets for LLM-related RS topics should maintain the original samantic/tex
 | MovieLens | Movie | [[Link]](https://grouplens.org/datasets/movielens/1m/) |
 | Amazon | E-commerce | [[Link]](https://cseweb.ucsd.edu/~jmcauley/datasets.html#amazon_reviews) |
 | BookCrossing | Book | [[Link]](http://www2.informatik.uni-freiburg.de/~cziegler/BX/) |
-| GoodReads | Book | [[Link]](https://sites.google.com/eng.ucsd.edu/ucsdbookgraph/home) |
+| GoodReads | Book | [[Link]](https://mengtingwan.github.io/data/goodreads.html) |
 | Anime | Anime | [[Link]](https://www.kaggle.com/datasets/CooperUnion/anime-recommendations-database) |
 | TABLET | Tabular | [[Link]](https://dylanslacks.website/Tablet) |
 


### PR DESCRIPTION
The old link points to a website with a warning that it is being deprecated. This PR updates the link to the recommended one.